### PR TITLE
update CPUGenerator and CUDAGenerator for Torch 1.6.0

### DIFF
--- a/csrc/cpu/reservoir_sampling.cpp
+++ b/csrc/cpu/reservoir_sampling.cpp
@@ -5,7 +5,7 @@ void generate_keys(
   float *keys,
   float *weights,
   int n,
-  at::CPUGenerator* generator
+  at::CPUGeneratorImpl* generator
 ){
   std::lock_guard<std::mutex> lock(generator->mutex_);
   at::uniform_real_distribution<double> standard_uniform(0.0, 1.0);
@@ -21,7 +21,7 @@ void reservoir_generator_cpu(
   int64_t *indices,
   int64_t n,
   int64_t k,
-  at::CPUGenerator* generator
+  at::CPUGeneratorImpl* generator
 ){
   std::lock_guard<std::mutex> lock(generator->mutex_);
 
@@ -53,8 +53,8 @@ at::Tensor reservoir_sampling_cpu(
   );
 
   auto options = x.options().dtype(at::kLong);
-  at::CPUGenerator* generator = at::get_generator_or_default<at::CPUGenerator>(
-                              nullptr,
+  at::CPUGeneratorImpl* generator = at::get_generator_or_default<at::CPUGeneratorImpl>(
+			      at::detail::getDefaultCPUGenerator(),
                               at::detail::getDefaultCPUGenerator()
                             );
 
@@ -165,8 +165,8 @@ at::Tensor sampling_with_replacement_cpu(
       "The weights must 1-dimensional."
     );
 
-    at::CPUGenerator* generator = at::get_generator_or_default<at::CPUGenerator>(
-                                nullptr,
+    at::CPUGeneratorImpl* generator = at::get_generator_or_default<at::CPUGeneratorImpl>(
+                	        at::detail::getDefaultCPUGenerator(),
                                 at::detail::getDefaultCPUGenerator()
                               );
 

--- a/csrc/cpu/reservoir_sampling.cpp
+++ b/csrc/cpu/reservoir_sampling.cpp
@@ -5,7 +5,11 @@ void generate_keys(
   float *keys,
   float *weights,
   int n,
+#ifdef TORCH_1_6
   at::CPUGeneratorImpl* generator
+#else
+  at::CPUGenerator* generator
+#endif
 ){
   std::lock_guard<std::mutex> lock(generator->mutex_);
   at::uniform_real_distribution<double> standard_uniform(0.0, 1.0);
@@ -21,7 +25,11 @@ void reservoir_generator_cpu(
   int64_t *indices,
   int64_t n,
   int64_t k,
+#ifdef TORCH_1_6
   at::CPUGeneratorImpl* generator
+#else
+  at::CPUGenerator* generator
+#endif
 ){
   std::lock_guard<std::mutex> lock(generator->mutex_);
 
@@ -53,10 +61,17 @@ at::Tensor reservoir_sampling_cpu(
   );
 
   auto options = x.options().dtype(at::kLong);
+#ifdef TORCH_1_6
   at::CPUGeneratorImpl* generator = at::get_generator_or_default<at::CPUGeneratorImpl>(
 			      at::detail::getDefaultCPUGenerator(),
-                              at::detail::getDefaultCPUGenerator()
-                            );
+			      at::detail::getDefaultCPUGenerator()
+			    );
+#else
+  at::CPUGenerator* generator = at::get_generator_or_default<at::CPUGenerator>(
+			      nullptr,
+			      at::detail::getDefaultCPUGenerator()
+			    );
+#endif
 
   if (weights.numel() == 0){ // Uniform Sampling
     at::Tensor indices_n = at::arange({n}, options);
@@ -164,11 +179,17 @@ at::Tensor sampling_with_replacement_cpu(
       weights.dim() == 1,
       "The weights must 1-dimensional."
     );
-
+#ifdef TORCH_1_6
     at::CPUGeneratorImpl* generator = at::get_generator_or_default<at::CPUGeneratorImpl>(
-                	        at::detail::getDefaultCPUGenerator(),
-                                at::detail::getDefaultCPUGenerator()
-                              );
+			      at::detail::getDefaultCPUGenerator(),
+			      at::detail::getDefaultCPUGenerator()
+			    );
+#else
+    at::CPUGenerator* generator = at::get_generator_or_default<at::CPUGenerator>(
+			      nullptr,
+			      at::detail::getDefaultCPUGenerator()
+			    );
+#endif
 
     samples = at::empty({k}, x.options().dtype(at::kLong));
     int64_t *samples_ptr = samples.data_ptr<int64_t>();

--- a/csrc/cpu/reservoir_sampling.h
+++ b/csrc/cpu/reservoir_sampling.h
@@ -1,6 +1,10 @@
 #include <torch/extension.h>
 #include <ATen/core/Generator.h>
+#ifdef TORCH_1_6
 #include <ATen/CPUGeneratorImpl.h>
+#else
+#include <ATen/CPUGenerator.h>
+#endif
 #include <ATen/core/DistributionsHelper.h>
 
 #include <math.h>

--- a/csrc/cpu/reservoir_sampling.h
+++ b/csrc/cpu/reservoir_sampling.h
@@ -1,6 +1,6 @@
 #include <torch/extension.h>
 #include <ATen/core/Generator.h>
-#include <ATen/CPUGenerator.h>
+#include <ATen/CPUGeneratorImpl.h>
 #include <ATen/core/DistributionsHelper.h>
 
 #include <math.h>

--- a/csrc/cuda/reservoir_sampling.cu
+++ b/csrc/cuda/reservoir_sampling.cu
@@ -102,10 +102,17 @@ at::Tensor reservoir_sampling_cuda(
   auto options = x.options().dtype(at::kLong);
   dim3 threads(threadsPerBlock);
 
+#ifdef TORCH_1_6
   auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
     at::cuda::detail::getDefaultCUDAGenerator(),
     at::cuda::detail::getDefaultCUDAGenerator()
   );
+#else
+  auto gen = at::get_generator_or_default<at::CUDAGenerator>(
+    nullptr,
+    at::cuda::detail::getDefaultCUDAGenerator()
+  );
+#endif
 
   std::pair<uint64_t, uint64_t> next_philox_seed;
   {
@@ -252,10 +259,17 @@ at::Tensor sampling_with_replacement_cuda(
     THAssert(props != NULL);
     int threadsPerBlock = props->maxThreadsPerBlock;
 
+#ifdef TORCH_1_6
     auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
       at::cuda::detail::getDefaultCUDAGenerator(),
       at::cuda::detail::getDefaultCUDAGenerator()
     );
+#else
+    auto gen = at::get_generator_or_default<at::CUDAGenerator>(
+      nullptr,
+      at::cuda::detail::getDefaultCUDAGenerator()
+    );
+#endif
 
     std::pair<uint64_t, uint64_t> next_philox_seed;
     {

--- a/csrc/cuda/reservoir_sampling.cu
+++ b/csrc/cuda/reservoir_sampling.cu
@@ -102,8 +102,8 @@ at::Tensor reservoir_sampling_cuda(
   auto options = x.options().dtype(at::kLong);
   dim3 threads(threadsPerBlock);
 
-  auto gen = at::get_generator_or_default<at::CUDAGenerator>(
-    nullptr,
+  auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
+    at::cuda::detail::getDefaultCUDAGenerator(),
     at::cuda::detail::getDefaultCUDAGenerator()
   );
 
@@ -252,8 +252,8 @@ at::Tensor sampling_with_replacement_cuda(
     THAssert(props != NULL);
     int threadsPerBlock = props->maxThreadsPerBlock;
 
-    auto gen = at::get_generator_or_default<at::CUDAGenerator>(
-      nullptr,
+    auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
+      at::cuda::detail::getDefaultCUDAGenerator(),
       at::cuda::detail::getDefaultCUDAGenerator()
     );
 

--- a/csrc/cuda/reservoir_sampling.cuh
+++ b/csrc/cuda/reservoir_sampling.cuh
@@ -4,7 +4,11 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
+#ifdef TORCH_1_6
 #include <ATen/CUDAGeneratorImpl.h>
+#else
+#include <ATen/CUDAGenerator.h>
+#endif
 #include <curand.h>
 #include <curand_kernel.h>
 #include <curand_philox4x32_x.h>

--- a/csrc/cuda/reservoir_sampling.cuh
+++ b/csrc/cuda/reservoir_sampling.cuh
@@ -4,7 +4,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <ATen/CUDAGenerator.h>
+#include <ATen/CUDAGeneratorImpl.h>
 #include <curand.h>
 #include <curand_kernel.h>
 #include <curand_philox4x32_x.h>

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import glob
 
 import torch
 from setuptools import setup
+from packaging import version
 from torch.utils.cpp_extension import CUDA_HOME
 from torch.utils.cpp_extension import CppExtension
 from torch.utils.cpp_extension import CUDAExtension
@@ -23,6 +24,9 @@ if torch.cuda.is_available() and CUDA_HOME is not None:
     extension = CUDAExtension
     sources += source_cuda
     define_macros += [("WITH_CUDA", None)]
+
+if version.parse(torch.__version__) >= version.parse('1.6.0'):
+    define_macros += [("TORCH_1_6", None)]
 
 setup(
     name='torch_sampling',


### PR DESCRIPTION
Fixes installation problems in https://github.com/LeviViana/torch_sampling/issues/3

Between torch 1.4.0 and 1.6.0 "CPUGenerator" became "CPUGeneratorImpl" and "CUDAGenerator" becamse "CUDAGeneratorImpl". The definition of get_generator_or_default must have also changed, and passing nullptr to the first argument failed. Instead, we just pass getDefaultCPUGenerator or getDefaultCUDAGenerator to both arguments.