### PR TITLE
fix include of deprecated THCTensorRandom.h in pytorch 1.9.0

### DIFF
--- a/csrc/cuda/reservoir_sampling.cuh
+++ b/csrc/cuda/reservoir_sampling.cuh
@@ -12,7 +12,11 @@
 #include <curand.h>
 #include <curand_kernel.h>
 #include <curand_philox4x32_x.h>
+#ifdef TORCH_1_8
+#include <TH/THTensor.h>
+#else
 #include <THC/THCTensorRandom.h>
+#endif
 #include <thrust/execution_policy.h>
 #include <thrust/binary_search.h>
 

--- a/csrc/cuda/reservoir_sampling.cuh
+++ b/csrc/cuda/reservoir_sampling.cuh
@@ -13,7 +13,7 @@
 #include <curand_kernel.h>
 #include <curand_philox4x32_x.h>
 #ifdef TORCH_1_8
-#include <TH/THTensor.h>
+#include <THC/THCTensor.h>
 #else
 #include <THC/THCTensorRandom.h>
 #endif

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,11 @@ if torch.cuda.is_available() and CUDA_HOME is not None:
 
 if version.parse(torch.__version__) >= version.parse('1.6.0'):
     define_macros += [("TORCH_1_6", None)]
+if version.parse(torch.__version__) > version.parse('1.8.0'):
+    define_macros += [("TORCH_1_8", None)]
+
+
+
 
 setup(
     name='torch_sampling',


### PR DESCRIPTION
Fixed PyTorch 1.9.0 install issue  #7.
The issue is that
`aten/src/THC/generic/THCTensorRandom.h` is removed in PyTorch 1.9.0.

To fix it, define a macro like in #4 and import `#include <THC/THCTensor.h>` instead of `#include <THC/THCTensorRandom.h>`
in ` torch_sampling/csrc/cuda/reservoir_sampling.cuh `.